### PR TITLE
Limit the maximum number of open files

### DIFF
--- a/dnabclib/main.py
+++ b/dnabclib/main.py
@@ -48,6 +48,13 @@ def main(argv=None):
     p.add_argument(
         "--total-reads-file", type=argparse.FileType("w"), help=(
             "Write TSV table of total read counts"))
+    p.add_argument(
+        "--max-open-samples", type=int, default=100, help=(
+            "Maximum number of samples for which the program will maintain "
+            "open filehandles as it writes sequences. Many systems impose "
+            "limits on the number of open filehandles for a single process. "
+            "For paired output, the number of open filehandles will be twice "
+            "the number of --max-open-samples."))
     args = p.parse_args(argv)
 
     samples = load_sample_barcodes(args.barcode_file)
@@ -60,7 +67,7 @@ def main(argv=None):
     if not os.path.exists(args.output_dir):
        os.mkdir(args.output_dir)
 
-    writer = PairedFastqWriter(args.output_dir)
+    writer = PairedFastqWriter(args.output_dir, max_open_samples=args.max_open_samples)
     assigner = BarcodeAssigner(
         samples, mismatches=args.mismatches, revcomp=args.revcomp)
     seq_file = SequenceFile(r1, r2, i1, i2)

--- a/dnabclib/main.py
+++ b/dnabclib/main.py
@@ -68,6 +68,8 @@ def main(argv=None):
        os.mkdir(args.output_dir)
 
     writer = PairedFastqWriter(args.output_dir, max_open_samples=args.max_open_samples)
+    writer.clear(samples)
+
     assigner = BarcodeAssigner(
         samples, mismatches=args.mismatches, revcomp=args.revcomp)
     seq_file = SequenceFile(r1, r2, i1, i2)

--- a/dnabclib/writer.py
+++ b/dnabclib/writer.py
@@ -80,6 +80,14 @@ class FastqWriter(_SequenceWriter):
 class PairedFastqWriter(FastqWriter):
     _get_output_fp = _get_sample_paired_fp
 
+    def clear(self, samples):
+        for sample in samples:
+            fp1, fp2 = self._get_output_fp(sample)
+            if os.path.exists(fp1):
+                os.remove(fp1)
+            if os.path.exists(fp2):
+                os.remove(fp2)
+
     def _open_filepath(self, fps):
         fp1, fp2 = fps
         f1 = super(PairedFastqWriter, self)._open_filepath(fp1)

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -79,6 +79,27 @@ class FastqWriterTests(unittest.TestCase):
             "unassigned\t1\n"
         ])
 
+    def test_write_cache(self):
+        s1 = MockSample("h56")
+        s2 = MockSample("123")
+        s3 = MockSample("khj")
+        w = FastqWriter(self.output_dir, max_open_samples = 1)
+
+        w.write(MockFastqRead("Read0", "ACCTTGG", "#######"), s1)
+        # Opening the file for s2 should close the file for s1
+        # Just to be sure, we write to s3
+        w.write(MockFastqRead("Read1", "ACCCCGG", "#######"), s2)
+        w.write(MockFastqRead("Read2", "GGGGGGG", "#######"), s3)
+        w.write(MockFastqRead("Read3", "AAAAAAA", "#######"), s1)
+        w.close()
+
+        fp = w._get_output_fp(s1)
+        with open(fp) as f:
+            obs_output = f.read()
+
+        self.assertEqual(
+            obs_output,
+            "@Read0\nACCTTGG\n+\n#######\n@Read3\nAAAAAAA\n+\n#######\n")
 
 class PairedFastqWriterTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This pull request adds a least-recently used (LRU) cache to the output file writer. Open files are maintained only for the N most recently detected samples, N=100 by default. The number of open output files is 2N for paired output. It's nice that Python has a convenient LRU cache decorator in the standard library.

One detail about this change is that we are now appending to output files as we open them, rather than clearing them out as we open them. Because of this change, I added a `clear()` method to the `Writer` object to remove any existing output files before we start assigning reads.

I have not tested this with a large input file, so I'm not sure how it affects speed for big jobs. I suspect it won't be too bad (famous last words), and I don't think we have a better option, in any case.